### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This quickstart provides an easy way to initiate a Django project using Docker. 
 
 3. **(Optional) Install the development requirements specific to your IDE for enhanced functionality and support.**
     ```bash
-    pip install -r src/requirements-dev.txt
+    pip install -r src/requirements.dev.txt
     ```
 
 4. **Build the image and run the container:**  


### PR DESCRIPTION
In README.md it says to run this command:

```bash
pip install -r src/requirements-dev.txt
```

But the file requirements-dev.txt no longer has the hyphen. 
![image](https://github.com/godd0t/django-docker-quickstart/assets/1836167/05c14daf-b524-492a-bb28-179a993c30b7)

It should be this:

```bash
pip install -r src/requirements.dev.txt
```